### PR TITLE
This branch is my first test of, well, branching a dev branch and mak…

### DIFF
--- a/src/flow/async/segregated_thread_task_loop.cpp
+++ b/src/flow/async/segregated_thread_task_loop.cpp
@@ -204,7 +204,9 @@ void Segregated_thread_task_loop::stop() // Virtual.
                 "each thread will be asked to gracefully terminate and be joined synchronously.  "
                 "Any subsequently-queued tasks will not run until start().");
 
+#ifndef NDEBUG
   size_t idx = 0;
+#endif
   for (Task_qing_thread_ptr& thread_ptr_in_container : m_qing_threads)
   {
     /* Consider E = thread_ptr_in_container->task_engine().  The following statement has the following effects,
@@ -232,7 +234,9 @@ void Segregated_thread_task_loop::stop() // Virtual.
     assert(m_task_engines[idx]->stopped());
     // Any pending tasks on that Task_engine now await another thread to ->run().  Then the queue will resume.
 
+#ifndef NDEBUG
     ++idx;
+#endif
   } // for (thread_ptr_in_container : m_qing_threads)
 
   /* Now every thread in the thread pool has exited.  Therefore by definition no post()ed tasks on `*this` will

--- a/src/flow/net_flow/detail/low_lvl_packet.cpp
+++ b/src/flow/net_flow/detail/low_lvl_packet.cpp
@@ -657,7 +657,6 @@ bool Data_packet::deserialize_type_specific_data_from_raw_data_packet(Const_buff
 {
   using boost::asio::buffer;
   using boost::endian::little_to_native;
-  using std::move;
   using std::numeric_limits;
 
   using data_size_raw_t = decltype(m_data_size_raw);
@@ -752,7 +751,7 @@ bool Data_packet::deserialize_type_specific_data_from_raw_data_packet(Const_buff
   }
   else
   {
-    m_data = move(*raw_packet);
+    m_data = std::move(*raw_packet);
     // Then shift begin() right to where the payload begins (size() adjusted down accordingly).
     m_data.start_past_prefix(cur_data - m_data.const_data());
     assert(m_data.const_begin() == cur_data);

--- a/src/flow/net_flow/detail/low_lvl_packet.hpp
+++ b/src/flow/net_flow/detail/low_lvl_packet.hpp
@@ -1224,7 +1224,9 @@ struct Ack_packet::Individual_ack
  * array of these `struct`s and transmit that entire array over the network with no need for scatter/gather
  * or any additional transformation of data post-construction and pushing onto aforementioned array.
  * These are copy-constructible, for pushing onto containers and such, but not assignable to avoid unnecessary
- * copying.
+ * copying.  Update: A later version of `clang` does not like
+ * this technique and warns about it; to avoid any such trouble just forget the non-assignability stuff;
+ * it's internal code; we should be fine.
  *
  * @see Historical note in Ack_packet::serialize_to_raw_data() explains why this and
  *      Individual_ack_rexmit_on both exist, instead of simply using Individual_ack in both directions.
@@ -1258,14 +1260,9 @@ struct Ack_packet::Individual_ack_rexmit_off
    *        #m_delay.
    */
   explicit Individual_ack_rexmit_off(const Sequence_number& seq_num, ack_delay_t delay);
-
-  // Methods.
-
-  /// Forbid copy assignment.
-  void operator=(const Individual_ack_rexmit_off&) = delete;
 };
 
-/// Equivalent of Individual_ack_rexmit_on but for sockets with retransmission enabled.
+/// Equivalent of `Individual_ack_rexmit_off` but for sockets with retransmission enabled.
 struct Ack_packet::Individual_ack_rexmit_on
 {
   // Data.
@@ -1294,11 +1291,6 @@ struct Ack_packet::Individual_ack_rexmit_on
    *        Individual_ack_rexmit_off::m_delay.
    */
   explicit Individual_ack_rexmit_on(const Sequence_number& seq_num, unsigned int rexmit_id, ack_delay_t delay);
-
-  // Methods.
-
-  /// Forbid copy assignment.
-  void operator=(const Individual_ack_rexmit_on&) = delete;
 };
 
 /**

--- a/src/flow/net_flow/detail/socket_buffer.cpp
+++ b/src/flow/net_flow/detail/socket_buffer.cpp
@@ -41,7 +41,6 @@ size_t Socket_buffer::feed_buf_move(util::Blob* data, size_t max_data_size)
   using util::Blob;
   using boost::asio::const_buffer;
   using boost::asio::buffer;
-  using std::move;
 
   const size_t orig_data_size = m_data_size;
 
@@ -75,7 +74,7 @@ size_t Socket_buffer::feed_buf_move(util::Blob* data, size_t max_data_size)
     else
     {
       // Enough space for all of *data -- so just use a constant-time swap.
-      Blob_ptr bytes_ptr(new Blob(move(*data))); // Move inner representation of *data into *bytes_ptr.
+      Blob_ptr bytes_ptr(new Blob(std::move(*data))); // Move inner representation of *data into *bytes_ptr.
       // *data empty now.
 
       m_q.push_back(bytes_ptr);
@@ -104,7 +103,6 @@ size_t Socket_buffer::feed_buf_move(util::Blob* data, size_t max_data_size)
 void Socket_buffer::consume_buf_move(util::Blob* target_buf, size_t max_data_size)
 {
   using util::Blob;
-  using std::move;
 
   if (m_data_size == 0)
   {
@@ -127,7 +125,7 @@ void Socket_buffer::consume_buf_move(util::Blob* target_buf, size_t max_data_siz
   {
     // Either the first block is perfectly sized, or it fits AND is the only one in the sequence.
 
-    *target_buf = move(front_buf); // Constant-time operation (swap internal buffer representations).
+    *target_buf = std::move(front_buf); // Constant-time operation (swap internal buffer representations).
     m_q.pop_front();
     // Whatever they had in *target_buf is junk.  Deleted!
     m_data_size -= target_buf->size();

--- a/src/flow/net_flow/peer_socket.cpp
+++ b/src/flow/net_flow/peer_socket.cpp
@@ -452,14 +452,12 @@ Peer_socket::Received_packet::Received_packet(log::Logger* logger_ptr, size_t si
   m_size(size),
   m_data(logger_ptr)
 {
-  using std::move;
-
   if (src_data)
   {
     // Retransmission is on: save *src_data for later reassembly.
     assert(m_size == size); // As promised in docs....
 
-    m_data = move(*src_data); // O(1) operation -- *src_data is probably cleared.
+    m_data = std::move(*src_data); // O(1) operation -- *src_data is probably cleared.
   }
 }
 
@@ -4500,7 +4498,7 @@ void Node::setup_drop_timer(const Socket_id& socket_id, Peer_socket::Ptr sock)
    * Additionally, when events m_snd_drop_timer wants to know about happen, we will call
    * m_snd_drop_timer->on_...(). */
   sock->m_snd_drop_timer = Drop_timer::create_drop_timer(get_logger(), &m_task_engine, &sock->m_snd_drop_timeout,
-                                                         std::move(sock), on_fail, on_timer);
+                                                         Peer_socket::Ptr(sock), on_fail, on_timer);
 }
 
 size_t Node::send(Peer_socket::Ptr sock,

--- a/src/flow/net_flow/peer_socket.hpp
+++ b/src/flow/net_flow/peer_socket.hpp
@@ -2275,7 +2275,9 @@ struct Peer_socket::Sent_packet :
  *
  * Data store to keep timing related info when a packet is sent out.  Construct via direct member initialization.
  * It is copy-constructible (for initially copying into containers and such) but not assignable to discourage
- * unneeded copying (though it is not a heavy structure).
+ * unneeded copying (though it is not a heavy structure).  Update: A later version of `clang` does not like
+ * this technique and warns about it; to avoid any such trouble just forget the non-assignability stuff;
+ * it's internal code; we should be fine.
  */
 struct Peer_socket::Sent_packet::Sent_when
 {
@@ -2323,16 +2325,6 @@ struct Peer_socket::Sent_packet::Sent_when
    */
   // That @internal should not be necessary to hide the @todo in public generated docs -- Doxygen bug?
   size_t m_sent_cwnd_bytes;
-
-  // Constructors/destructor.
-
-  /// Force direct member initialization even if no member is `const`.
-  Sent_when() = delete;
-
-  // Methods.
-
-  /// Forbid copy assignment.
-  void operator=(const Sent_when&) = delete;
 }; // struct Peer_socket::Sent_packet::Sent_when
 
 /**
@@ -2424,7 +2416,7 @@ struct Peer_socket::Individual_ack
   // Methods.
 
   /// Forbid copy assignment.
-  void operator=(const Individual_ack&) = delete;
+  Individual_ack& operator=(const Individual_ack&) = delete;
 }; // struct Peer_socket::Individual_ack
 
 // Free functions: in *_fwd.hpp.


### PR DESCRIPTION
…ing some fixes -- perhaps with a PR.  I had not tried clang yet (colleague added it recently); this gave me a chance to do that too.  As a result:

- Found a few more not-scary build errors revealed by clang-17: a few pedantic warnings, an assert()-unused-variable thing, and a pedantic but reasonable C++ subtlety.  Fixed those, so clang-17 is cool.
- Found a regression added recently when colleague and/or I was/were fixing some minor Coverity-found stuff.  Turns out it broke a basic NetFlow thing by introducing a use-after-move() problem (a really obvious one; should have been seen in code review; it happens).  When I ran the test program for Flow, which focuses on NetFlow, it was an obvious run-time error due to dereferencing a moved-from (null) shared_ptr.  After this fix it is fine.
  - NetFlow is, at this stage, a demo/test thing (albeit a fancy one).  Still this kind of stuff reinforces that we should add unit-testing (as if it was not obvious).