### PR TITLE
Shorter/less repeating output about version # and such. / There is a …

### DIFF
--- a/tools/cmake/FlowLikeDocGenerate.cmake
+++ b/tools/cmake/FlowLikeDocGenerate.cmake
@@ -67,8 +67,7 @@
 #     figures.
 # All those paths shall be specified relative to the project root (same place as the root CMakeLists.txt).
 
-message(CHECK_START "(Project [${PROJ}] (CamelCase [${PROJ_CAMEL}], human-friendly "
-                      "[${PROJ_HUMAN}]), version [${PROJ_VERSION}]: creating doc-generation targets.)")
+message(CHECK_START "(Project [${PROJ}]: creating doc-generation targets.)")
 list(APPEND CMAKE_MESSAGE_INDENT "- ")
 
 if(NOT CFG_ENABLE_DOC_GEN)

--- a/tools/cmake/FlowLikeLib.cmake
+++ b/tools/cmake/FlowLikeLib.cmake
@@ -138,7 +138,7 @@ list(APPEND CMAKE_MESSAGE_INDENT "- ")
 if(DEFINED BOOST_LIBS)
   set(BOOST_VER 1.83) # Current as of Oct 2023.
 
-  message(CHECK_START "Finding dep: Boost-${BOOST_VER}: headers plus libs [${BOOST_LIBS}].")
+  message(CHECK_START "(Finding dep: Boost-${BOOST_VER}: headers plus libs [${BOOST_LIBS}].)")
   list(APPEND CMAKE_MESSAGE_INDENT "- ")
 
   # Boost is necessary.


### PR DESCRIPTION
…small issue when CMake-ing an individual Flow-like project without a meta-project (e.g., `flow`).  Setting a variable in parent scope issues a non-fatal warning, as there is no parent scope.  Now guarding against that.  Also qualifying a couple of names since they could (in an obscure situation) live in a non-Flow-like user project scope; avoid name conflict.