### PR TITLE
FLOW_ERROR_EXEC*_AND_THROW_ON_ERROR() now computes the where-am-i str…

### DIFF
--- a/src/flow/error/error.cpp
+++ b/src/flow/error/error.cpp
@@ -24,7 +24,7 @@ namespace flow::error
 // Implementations.
 
 Runtime_error::Runtime_error(const Error_code& err_code_or_success, util::String_view context) :
-  // This strange-looking dichotomy is explained in ###Rationale### in m_context doc header.
+  // This strange-looking dichotomy is explained in ###Rationale### in m_context_if_no_code doc header.
   boost::system::system_error(err_code_or_success,
                               err_code_or_success
                                 ? std::string(context)
@@ -45,7 +45,7 @@ Runtime_error::Runtime_error(util::String_view context) :
 
 const char* Runtime_error::what() const noexcept // Virtual.
 {
-  // This dichotomy is explained in ###Rationale### in m_context doc header.  See ctor above also.
+  // This dichotomy is explained in ###Rationale### in m_context_if_no_code doc header.  See ctor above also.
   return code()
            ? boost::system::system_error::what()
            : m_context_if_no_code.c_str();

--- a/src/flow/error/error_fwd.hpp
+++ b/src/flow/error/error_fwd.hpp
@@ -81,6 +81,8 @@ class Runtime_error;
  *        and `func()` encountered an error.
  * @param context
  *        Value suitable for the `context` argument of Runtime_error constructor.
+ *        Most likely this should be something it takes little to no runtime computation to obtain;
+ *        so either your own string literal; or FLOW_UTIL_WHERE_AM_I_LITERAL().
  * @return `true` if and only if `err_code` is null; and therefore `func()` was called.
  *         `false` otherwise (i.e., `err_code` is not null; nothing was done; and the caller should perform the
  *         equivalent of `func()` while safely assuming `*err_code` may be assigned to upon error).

--- a/src/flow/util/basic_blob.hpp
+++ b/src/flow/util/basic_blob.hpp
@@ -2195,6 +2195,7 @@ typename Basic_blob<Allocator, S_SHARING_ALLOWED>::Iterator
 #pragma GCC diagnostic ignored "-Wpragmas" // For older versions, where the following does not exist/cannot be disabled.
 #pragma GCC diagnostic ignored "-Wunknown-warning-option" // (Similarly for clang.)
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wrestrict" // Another similar bogus one pops up after pragma-ing away preceding one.
 
     /* Likely linear-time in `n` but hopefully optimized.  Could use a C++ construct, but I've seen that be slower
      * that a direct memcpy() call in practice, at least in a Linux gcc.  Could use boost.asio buffer_copy(), which
@@ -2242,6 +2243,7 @@ typename Basic_blob<Allocator, S_SHARING_ALLOWED>::Const_iterator
 #pragma GCC diagnostic ignored "-Wpragmas" // For older versions, where the following does not exist/cannot be disabled.
 #pragma GCC diagnostic ignored "-Wunknown-warning-option" // (Similarly for clang.)
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wrestrict"
     memcpy(dest_data, src, n);
 #pragma GCC diagnostic pop
   }
@@ -2271,6 +2273,7 @@ typename Basic_blob<Allocator, S_SHARING_ALLOWED>::Iterator
 #pragma GCC diagnostic ignored "-Wpragmas" // For older versions, where the following does not exist/cannot be disabled.
 #pragma GCC diagnostic ignored "-Wunknown-warning-option" // (Similarly for clang.)
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wrestrict"
       memmove(dest, iterator_sans_const(past_last), n_moved); // Cannot use memcpy() due to possible overlap.
 #pragma GCC diagnostic pop
     }

--- a/src/flow/util/detail/util.hpp
+++ b/src/flow/util/detail/util.hpp
@@ -130,3 +130,66 @@ constexpr String_view get_last_path_segment(String_view full_path)
  */
 #define FLOW_UTIL_WHERE_AM_I_FROM_ARGS_TO_ARGS(ARG_file, ARG_function, ARG_line) \
   ::flow::util::get_last_path_segment(ARG_file), ':', ARG_function, '(', ARG_line, ')'
+
+/**
+ * Helper macro: like FLOW_UTIL_WHERE_AM_I(), with a major relative strength -- its replacement is a string literal --
+ * and two differences: the function name must be supplied verbatim as an arg; and the source file name
+ * will contain the entire path as opposed to a massaged version with just the file-name component.
+ * The key is that the function name arg is not to be a string: it is *stringified* to get the string.
+ *
+ * Nevertheless, in perf-sensitive scenarios, this may well be worth it.  For now we keep it in a detail/ header
+ * for use internally to Flow; we did in fact need this in flow::error.
+ *
+ * Other than the aforementioned difference and mild formatting tweaks for cosmetics (as of this writing an added
+ * space), the format of the replacement's contents is identical to that from FLOW_UTIL_WHERE_AM_I().
+ *
+ * ### Rationale ###
+ * Why need `ARG_function`?  Why not simply use `__FUNCTION__` internally?  Answer: Despite its similar look
+ * to `__FILE__`, actually `__FUNCTION__` is *not* a macro: it is an identifier (that refers to a `const char*`).
+ * The preprocessor knows what file (and line) it's scanning; but it has no idea what func it's scanning;
+ * that's only known at a later stage of compilation.  So long story short: `__FUNCTION__` is not replaced
+ * by a string literal and thus cannot be used to compose a string literal by compile-time concatenation.
+ *
+ * (`constexpr` sweetness can be used for an otherwise compile-time-determined value; but we promised a literal
+ * here.  `constexpr`ness is outside our scope.  Though perhaps see FLOW_UTIL_WHERE_AM_I_FROM_ARGS() for that.)
+ *
+ * @param ARG_function
+ *        Informally this is something akin to `ARG_function` to FLOW_ERROR_EXEC_AND_THROW_ON_ERROR().
+ *        Formally this can be anything; it will be stringified via `#ARG_function` and output as the function name.
+ *        (Do not attempt to pass here the name of a string-typed variable; that probably won't do
+ *        what you want.  E.g., if you invoke `FLOW_UTIL_WHERE_AM_I_LITERAL(func_name)`, and `func_name`
+ *        is an `std::string` with a function name, then the macro replacement will be
+ *        `"/some/file.cpp:func_name(332)"` --
+ *        without `func_name` getting replaced by the contents of your `func_name` variable or whatever.)
+ * @return A string literal containing file name (and path; from `__FILE__`), function name given, and
+ *         line number (from `__LINE__`).
+ *         The string literal will be in the form `"stuff" "more stuff" "more stuff"` (etc.).  There will be
+ *         no surrounding parentheses (in case you want to compile-time-concatenate to even more literal segments).
+ */
+#define FLOW_UTIL_WHERE_AM_I_LITERAL(ARG_function) \
+  FLOW_UTIL_WHERE_AM_I_LITERAL_IMPL_OUTER(ARG_function, __LINE__)
+
+/**
+ * Impl helper macro from FLOW_UTIL_WHERE_AM_I_LITERAL().  This intermediate between
+ * that guy and the "true" impl macro FLOW_UTIL_WHERE_AM_I_LITERAL_IMPL_INNER() is needed in order for the
+ * preprocessor to substitute `__LINE__` instead of simply stringifying it as `"__LINE__"`.
+ *
+ * @param ARG_function
+ *        See FLOW_UTIL_WHERE_AM_I_LITERAL().
+ * @param ARG_line
+ *        Literally `__LINE__`.
+ */
+#define FLOW_UTIL_WHERE_AM_I_LITERAL_IMPL_OUTER(ARG_function, ARG_line) \
+  FLOW_UTIL_WHERE_AM_I_LITERAL_IMPL_INNER(ARG_function, ARG_line)
+
+/**
+ * Impl helper macro from FLOW_UTIL_WHERE_AM_I_LITERAL().  This is the real impl; see also
+ * FLOW_UTIL_WHERE_AM_I_LITERAL_IMPL_OUTER().
+ *
+ * @param ARG_function
+ *        See FLOW_UTIL_WHERE_AM_I_LITERAL().
+ * @param ARG_line
+ *        The line number integer as from `__LINE__`.
+ */
+#define FLOW_UTIL_WHERE_AM_I_LITERAL_IMPL_INNER(ARG_function, ARG_line) \
+  __FILE__ ": " #ARG_function "(" #ARG_line ")"


### PR DESCRIPTION
…ing at compile-time, as a string literal, to improve perf of every error-emitting API that uses that macro.  In Flow currently that is mostly net_flow, which these days is demo code, but in Flow-IPC it is also used; and it is a public API.