### PR TITLE
Opportunistic: Doing TODO which said to avoid putting install-path in…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  # Make it possible to trigger workflow manually.
   workflow_dispatch:
       
 jobs:
@@ -114,12 +115,16 @@ jobs:
           - { id: gcc-13, name: gcc, version: 13, c-path: /usr/bin/gcc-13, cpp-path: /usr/bin/g++-13 }
           - { id: clang-13, name: clang, version: 13, c-path: /usr/bin/clang-13, cpp-path: /usr/bin/clang++-13 }
           - { id: clang-15, name: clang, version: 15, c-path: /usr/bin/clang-15, cpp-path: /usr/bin/clang++-15 }
-          - { id: clang-16, name: clang, version: 16, c-path: /usr/bin/clang-16, cpp-path: /usr/bin/clang++-16, install: True }
-          - { id: clang-17, name: clang, version: 17, c-path: /usr/bin/clang-17, cpp-path: /usr/bin/clang++-17, install: True }  
+          - { id: clang-16, name: clang, version: 16, c-path: /usr/bin/clang-16, cpp-path: /usr/bin/clang++-16,
+              install: True }
+          - { id: clang-17, name: clang, version: 17, c-path: /usr/bin/clang-17, cpp-path: /usr/bin/clang++-17,
+              install: True }
         build-type:
           - { id: debug, conan-name: Debug, conan-preset: debug,  }
           - { id: release, conan-name: Release, conan-preset: release }
-          - { id: relwithdebinfo-tsan, conan-name: RelWithDebInfo, conan-preset: relwithdebinfo, conan-cxxflags: [ "'-fsanitize=thread'" ], conan-cflags: [ "'-fsanitize=thread'" ], conan-ldflags: [ "'-fsanitize=thread'" ] }
+          - { id: relwithdebinfo-tsan, conan-name: RelWithDebInfo, conan-preset: relwithdebinfo,
+              conan-cxxflags: [ "'-fsanitize=thread'" ], conan-cflags: [ "'-fsanitize=thread'" ],
+              conan-ldflags: [ "'-fsanitize=thread'" ] }
           - { id: relwithdebinfo, conan-name: RelWithDebInfo, conan-preset: relwithdebinfo }
           - { id: minsizerel, conan-name: MinSizeRel, conan-preset: minsizerel }
         exclude:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,13 +193,11 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v1
       id: cpu-cores
 
-    # TODO: It seems unusual to place install-prefix inside build-prefix.
     - name: Prepare Makefile using CMake
       run: |
-        cat $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/generators/conan_toolchain.cmake
         cmake \
           --preset ${{ matrix.build-type.conan-preset }} \
-          -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install
+          -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}
 
     - name: Build targets (library, demos/tests) with Makefile
       run: |
@@ -216,7 +214,7 @@ jobs:
 
     - name: Run demo/test [NetFlow echo]
       run: |
-          cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin/
+          cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin/
           ./net_flow_echo_srv.exec 8888 localhost & 
           sleep 1
           # This needs to return 0 exit-code.


### PR DESCRIPTION
…side build-path.  Still following Conan preset behavior which appends the build-type at the end of the prefix (so it will be build/BLAHHHH still but also install/BLAHHHH now instead of build/BLAHHHH/install).