### PR TITLE
Tsan fun

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
     env: 
       setup-tests-env: |
         if [ "${{ matrix.build-and-test-config.id }}" = relwithdebinfo-tsan ]; then
-          export TSAN_OPTIONS="disable_coredump=0 second_deadlock_stack=1 suppressions=${{ github.workspace }}/tsan_suppressions_${{ matrix.compiler.name }}_${{ matrix.compiler.version }}.cfg"
+          export TSAN_OPTIONS="disable_coredump=0 second_deadlock_stack=1 suppressions=${{ github.workspace }}/src/sanitize/tsan/suppressions_${{ matrix.compiler.name }}.cfg"
         fi
         
     steps:   

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore emacs auto-saves and recovery files; **/ to avoid picking it up as a comment.
+*~
+**/#*#
+
+# And this Mac stuff.
+.DS_Store

--- a/src/sanitize/msan/ignore_list_clang.cfg
+++ b/src/sanitize/msan/ignore_list_clang.cfg
@@ -1,0 +1,5 @@
+# boost.chrono duration global initializer => std::string uninit value (TODO: too general but...).
+# There is a number of these, including things like operator+() which are tough to specify in
+# this format; for now going in for a penny + pound, as they say: the entire file.
+[memory]
+src:*/bits/basic_string.h

--- a/src/sanitize/tsan/suppressions_clang.cfg
+++ b/src/sanitize/tsan/suppressions_clang.cfg
@@ -1,1 +1,2 @@
+# TODO: Explain this one.
 race:std::ctype<char>::narrow

--- a/tsan_suppressions_clang_15.cfg
+++ b/tsan_suppressions_clang_15.cfg
@@ -1,1 +1,0 @@
-race:std::ctype<char>::narrow

--- a/tsan_suppressions_clang_16.cfg
+++ b/tsan_suppressions_clang_16.cfg
@@ -1,1 +1,0 @@
-race:std::ctype<char>::narrow

--- a/tsan_suppressions_clang_17.cfg
+++ b/tsan_suppressions_clang_17.cfg
@@ -1,1 +1,0 @@
-race:std::ctype<char>::narrow


### PR DESCRIPTION
Small part of rejigger of how suppressions (and ignore-list for MSAN, used in a limited way) are organized. (TODO: flow pipeline, sanitizer-wise, needs to be looked at by me anyway; will get to that once `ipc` is good to go.) This works together with upcoming `ipc` and co. work, where I will explain more.