### PR TITLE
Style refactor (small): Encouraging static_assert(false) over `#error`. Encouraging `if constexpr` over SFINAE. / Comment and/or doc changes.

### DIFF
--- a/src/flow/async/concurrent_task_loop.cpp
+++ b/src/flow/async/concurrent_task_loop.cpp
@@ -105,7 +105,7 @@ void optimize_pinning_in_thread_pool(flow::log::Logger* logger_ptr,
   using ::thread_policy_set;
   // using ::THREAD_AFFINITY_POLICY; // Nope; it's a #define.
 #else
-#  error "We only know how to deal with thread-core affinities in Darwin/Mac and Linux."
+  static_assert(false, "We only know how to deal with thread-core affinities in Darwin/Mac and Linux.");
 #endif
   using boost::system::system_category;
   using std::runtime_error;
@@ -223,7 +223,7 @@ void optimize_pinning_in_thread_pool(flow::log::Logger* logger_ptr,
     }
     // else OK!
 #else
-#  error "Compiler should not have reached this point; serious bug?"
+    static_assert(false, "Compiler should not have reached this point; serious bug?");
 #endif
   } // for (thread_idx in [0, n_pool_threads))
 } // optimize_pinning_in_thread_pool()

--- a/src/flow/async/concurrent_task_loop.hpp
+++ b/src/flow/async/concurrent_task_loop.hpp
@@ -678,7 +678,7 @@ public:
 #    define FLOW_ASYNC_HW_THREAD_AFFINITY_PTHREAD_VIA_CORE_IDX 1
 #    define FLOW_ASYNC_HW_THREAD_AFFINITY_MACH_VIA_POLICY_TAG 0
 #  else
-#    error "We only know how to deal with thread-core affinities in Darwin/Mac and Linux."
+static_assert(false, "We only know how to deal with thread-core affinities in Darwin/Mac and Linux.");
 #  endif
 
 #endif // elif !defined(FLOW_DOXYGEN_ONLY)

--- a/src/flow/common.hpp
+++ b/src/flow/common.hpp
@@ -72,6 +72,7 @@
  * of the headers.  So at least C++14 has been required for ages in actual practice.  Later, notched it up to C++17
  * by similar logic. */
 #if (!defined(__cplusplus)) || (__cplusplus < 201703L)
+// Would use static_assert(false), but... it's C++11 and later only.  So.
 #  error "To compile a translation unit that `#include`s any flow/ API headers, use C++17 compile mode or later."
 #endif
 

--- a/src/flow/detail/doc/doc-coding_style.cpp
+++ b/src/flow/detail/doc/doc-coding_style.cpp
@@ -1388,7 +1388,15 @@ if (mutex.locked()) // Mutex being locked here means we are in trouble.
 // -- BEST PRACTICES: Error handling --
 
 // - Do: Use assert() for bad arg values as much as possible *unless* returning an error is worth it to user. -
-// - Do: Use static_assert() for compile-time checks. -
+// - Do: Use static_assert() for compile-time checks, or after failing an #if[def] (or other) compile-time check. -
+/* - Do not: Use `#error "<message>"` after failing an #if[def] (or other) compile-time check. -
+ *
+ * `static_assert(false, "<message>")` is quite a bit more convenient. */
+// - Do: Use `if constexpr()` for compile-time checks. -
+/* - Avoid: using SFINAE (look it up please) -- when possible. -
+ *
+ * SFINAE is tough to comprehend and code. `if constexpr()` often makes it unnecessary and is much easier
+ * to follow and code. */
 
 /* - Do: Use Flow's standard error reporting convention/boiler-plate when returning errors from a public lib API. -
  *

--- a/src/flow/log/log.cpp
+++ b/src/flow/log/log.cpp
@@ -60,7 +60,8 @@ void Logger::this_thread_set_logged_nickname(util::String_view thread_nickname, 
   if (also_set_os_name)
   {
 #ifndef FLOW_OS_LINUX
-#  error "this_thread_set_logged_nickname() also_set_os_name implementation is for Linux only."
+    static_assert(false, "this_thread_set_logged_nickname() also_set_os_name implementation is for Linux only "
+                           "for now.");
     /* `man pthread_setname_np` works in Darwin/Mac but is very short, and there is no `man pthread_getname_np`.
      * It might work fine for Mac, but it's untested, and I (ygoldfel) didn't want to deal with it yet.
      * In particular it's unclear if the MAX_PTHREAD_NAME_SZ would apply (it's not in `man` for Mac)... etc.

--- a/src/flow/net_flow/detail/low_lvl_io.cpp
+++ b/src/flow/net_flow/detail/low_lvl_io.cpp
@@ -372,7 +372,7 @@ void Node::async_low_lvl_packet_send_impl(const util::Udp_endpoint& low_lvl_remo
    * `packet`'s ref-count would drop to zero at method exit just below, and hence async_send_to() asynchronously
    * would crash a little later.)
    *
-   * Update: Through empirical evidence, I found that, at least with Boost 1.63 and Mac OS X, UDP async_send_to()
+   * Update: Through empirical evidence, I found that, at least with Boost 1.63 and macOS, UDP async_send_to()
    * below will silently truncate to the first 64 elements of raw_bufs.  I could find no evidence of this being
    * a common OS limitation (I've found other limits like 1024 in Linux for writev()), though I didn't dig very hard.
    * The silent truncation was quite alarming and something to look into if only for educational purposes.

--- a/src/flow/util/util.cpp
+++ b/src/flow/util/util.cpp
@@ -188,7 +188,8 @@ size_t deep_size(const std::string& val)
   // We're following the loose pattern explained at the end of Async_file_logger::mem_cost().
 
 #if (!defined(__GNUC__)) || (!defined(__x86_64__))
-#  error "An estimation trick below has only been checked with x64 gcc and clang.  Revisit code for other envs."
+  static_assert(false, "An estimation trick below has only been checked with x64 gcc and clang.  "
+                         "Revisit code for other envs.");
 #endif
 
   /* If it is long enough to not fit inside the std::string object itself

--- a/src/flow/util/util_fwd.hpp
+++ b/src/flow/util/util_fwd.hpp
@@ -166,7 +166,7 @@ using Strand = Task_engine::strand;
  *     (Note: This Linux's `glibc` is too old to provide the `timerfd` API, therefore Boost falls back to
  *     using `epoll_wait()` directly; on a newer Linux this may get better results.)
  *   - Windows 7: 15 millisecond resolution, with little variance.
- *   - Mac OS X: untested.  @todo Test Mac OS X timer fidelity.
+ *   - macOS: untested.  @todo Test macOS timer fidelity.
  *
  * These results were observed for BOTH `deadline_timer` and `basic_waitable_timer<Fine_clock>`
  * in Boost 1.50.  Thus, there was no resolution advantage to using the latter -- only an interface advantage.


### PR DESCRIPTION
relates to issue #88 