### PR TITLE
(see Description) 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(fmt REQUIRED)
 list(APPEND DEP_LIBS fmt::fmt)
 list(APPEND DEP_LIBS_PKG_ARG_LISTS fmt::fmt)
 
-# (See above if wondering why we're not auto-searching for these.  There's a good reason.)
+# (See comment in FlowLikeLib.cmake if wondering why we're not auto-searching for these.  There's a good reason.)
 # Ideally keep this in `find -s` order.
 set(SRCS
     flow/async/concurrent_task_loop.cpp

--- a/src/flow/detail/doc/doc-coding_style.cpp
+++ b/src/flow/detail/doc/doc-coding_style.cpp
@@ -904,7 +904,7 @@ T* x = 0; // This is the Flow convention.  Note, no `NULL`!  NULL is C stuff, no
  *   - Enumerations and templates thereof:
  *     - It must be declared/defined exactly once, together with its full Doxygen docs (including leading
  *       doc header).  Do not forward-declare.  (Rationale omitted: But trust us; trying to fwd-declare it is
- *       more trouble than it is worth; and avoiding it generally plays with with other nearby conventions.)
+ *       more trouble than it is worth; and avoiding it generally well with other nearby conventions.)
  *   - Type aliases:
  *     - It must be declared/defined exactly once (as required by C++), together with its Doxygen doc header.
  *   - Varibles and constants (non-`constexpr`):
@@ -946,7 +946,7 @@ T* x = 0; // This is the Flow convention.  Note, no `NULL`!  NULL is C stuff, no
  * pain is likely to occur down the line.  We talk about good exception cases below.  For now let's forge on:
  *
  * That rule, in and of itself, is pretty simple.  Got a thing that must be declared/defined or forward-declared?
- * Put it in a _fwd.hpp.  If there's only one definitin/declaration, then that's that.  If there's also a 2nd
+ * Put it in a _fwd.hpp.  If there's only one definition/declaration, then that's that.  If there's also a 2nd
  * definition/declaration (aggregate types/templates thereof; variables/constants; free functions/templates) then:
  *   - Any code requiring use of a given symbol can include the relevant _fwd.hpp when only a forward-declaration
  *     is required; e.g., if only referring to forward-declared type `T` by pointer or reference.
@@ -954,7 +954,7 @@ T* x = 0; // This is the Flow convention.  Note, no `NULL`!  NULL is C stuff, no
  *     header.
  *
  * This allows for (1) shorter build times; and (arguably more importantly) (2) the methodical pre-disentangling of
- * hairy circular-reference nightmares during to C++'s single-pass compilation model.
+ * hairy circular-reference nightmares due to C++'s single-pass compilation model.
  *
  * The convention gets somewhat annoying when it comes to the details of *which* _fwd.hpp to place the
  * declaration.  We note that different libraries do different things and not very consistently at that.  We give
@@ -973,7 +973,7 @@ T* x = 0; // This is the Flow convention.  Note, no `NULL`!  NULL is C stuff, no
  *       Use common sense/analogy thinking.
  *   - At any dir level, for a given C.hpp focused on central aggregate type (or aggregate type template, or namespace,
  *     or compact feature or ...) named ~C, there is potentially (not necessarily) C_fwd.hpp in the same dir.
- *     This is known as *header-specific forward-header.
+ *     This is known as *header-specific forward-header*.
  *
  * First decide which of the ~3 locations your declaration belongs in; then create that _fwd.hpp if needed; and
  * then put the declaration there in the appropriate section.  So which one should it be?  Answer: it shall be either
@@ -1043,7 +1043,7 @@ T* x = 0; // This is the Flow convention.  Note, no `NULL`!  NULL is C stuff, no
  *       data members outside of `static` constants -- so only a ctor/method API and/or static constants.  If this
  *       added API + constants is small enough -- e.g., adding convenience constructor(s)
  *       and/or a couple compatibility accessors -- then it can go into _fwd.hpp.  Omit the forward-declaration;
- *       declare directly in _fwd.hpp; okace the doc header as you would normally in non-_fwd.hpp.  This class
+ *       declare directly in _fwd.hpp; place the doc header as you would normally in non-_fwd.hpp.  This class
  *       is "almost" an alias to its superclass.
  *       - If the class/class template C is too large to stylistically belong in a module-level _fwd.hpp, you might
  *         place it into its own C.hpp; but it is then okay to `include` in that _fwd.hpp.  If C is oft-used, this
@@ -1346,10 +1346,9 @@ if (mutex.locked()) // Mutex being locked here means we are in trouble.
 /* - Corollary: Use, e.g., `using Thread = <std or boost>::thread` for commonly used things from STL/Boost features. -
  *
  * [Rationale: 2 benefits.  One, if it's commonly used then this increases pithiness and cosmetic consistency.
- * Two, particularly for items in both STL and Boost, it makes it easy to switch the underlying implementation
- * easily.] */
+ * Two, particularly for items in both STL and Boost, it makes it easy to switch the underlying implementation.] */
 
-/* - Do: In particular, familiarize self with these boost. modules: -
+/* - Do: In particular, familiarize self with these boost.* modules: -
  *
  *   Basic tools (should be familiar at minimum):
  *     any, array, chrono^, core, dynamic_bitset, lexical_cast, random*, unordered#,
@@ -1381,9 +1380,9 @@ if (mutex.locked()) // Mutex being locked here means we are in trouble.
  *     better or at least not-worse perf due to native nature of it.  It can go either way; but current preference
  *     in Flow has switched to std::atomic.  (A perf bake-off might be nice, but std::atomic really should be safe
  *     and full-featured.)
- * -!- Boost.function is, it turns out, horrendously slow (too much capture copying).  Plus it has a 10-arg limit.
- *     std::function in gcc looks great in both regards though lacking some very minor APIs from Boost.function.
- *     Just use flow::Function: it's the best of both worlds.  Definitely do not use Boost.function! */
+ * -!- boost.function is, it turns out, horrendously slow (too much capture copying).  Plus it has a 10-arg limit.
+ *     std::function in gcc looks great in both regards though lacking some very minor APIs from boost.function.
+ *     Just use flow::Function: it's the best of both worlds.  Definitely do not use boost.function! */
 
 // -- BEST PRACTICES: Error handling --
 

--- a/src/flow/log/log.cpp
+++ b/src/flow/log/log.cpp
@@ -74,8 +74,8 @@ void Logger::this_thread_set_logged_nickname(util::String_view thread_nickname, 
     constexpr size_t MAX_PTHREAD_NAME_SZ = 15;
     if (os_name.size() > MAX_PTHREAD_NAME_SZ)
     {
-      // As advertised: Truncate from the front to increase chance resulting name is still disambiguated from others.
-      os_name.erase(0, os_name.size() - MAX_PTHREAD_NAME_SZ);
+      // As advertised: Truncate.  `man` indicates not doing so shall lead to ERANGE error.
+      os_name.erase(MAX_PTHREAD_NAME_SZ);
     }
 
     const auto result_code = pthread_setname_np(pthread_self(), os_name.c_str());
@@ -87,7 +87,7 @@ void Logger::this_thread_set_logged_nickname(util::String_view thread_nickname, 
       if (result_code == -1)
       {
         const Error_code sys_err_code(errno, system_category());
-        FLOW_LOG_WARNING("Unable to set OS thread name to [" << os_name << "], possibly truncated from the front "
+        FLOW_LOG_WARNING("Unable to set OS thread name to [" << os_name << "], possibly truncated "
                          "to [" << MAX_PTHREAD_NAME_SZ << "] characters, via pthread_setname_np().  "
                          "This should only occur due to an overlong name, which we guard against, so this is "
                          "highly unexpected.  Details follow.");
@@ -95,7 +95,7 @@ void Logger::this_thread_set_logged_nickname(util::String_view thread_nickname, 
       }
       else
       {
-        FLOW_LOG_INFO("OS thread name has been set to [" << os_name << "], possibly truncated from the front "
+        FLOW_LOG_INFO("OS thread name has been set to [" << os_name << "], possibly truncated "
                       "to [" << MAX_PTHREAD_NAME_SZ << "] characters.");
       }
     }

--- a/src/flow/log/log.hpp
+++ b/src/flow/log/log.hpp
@@ -1403,8 +1403,6 @@ public:
    *     - Note: Because "Initial" and "Blank" are necessarily not the same, it is recommended to call
    *       this_thread_set_logged_nickname() around thread creation time even if `thread_nickname` is blank.
    *       Then `ps`, `top`, etc. output will still be useful and possible to cross-reference with log output, say.
-   *     - Note: Truncation will be reverse, meaning -- if necessary -- *leading* characters will be eliminated.
-   *       This, in practice, tends to at least help disambiguate in case of truncation.
    *     - Note: N is documented in `man pthread_setname_np` as 15 not counting the NUL terminator.
    *       Therefore ideally keep the `thread_nickname.size()` to at most N.
    *

--- a/src/flow/perf/checkpt_timer.hpp
+++ b/src/flow/perf/checkpt_timer.hpp
@@ -73,7 +73,7 @@ namespace flow::perf
  * lowest possible overhead:
  *
  *   ~~~
- *   flow::perf::Checkpointing_timer sum_timer("op name", which_clocks, 1, logger); // 1 checkpoint only.
+ *   flow::perf::Checkpointing_timer sum_timer(logger, "op name", which_clocks, 1); // 1 checkpoint only.
  *   const unsigned int n_samples = 1000000;
  *   for (unsigned int sample_idx = 0; sample_idx != n_samples; ++sample_idx)
  *   {

--- a/src/flow/util/basic_blob.hpp
+++ b/src/flow/util/basic_blob.hpp
@@ -339,7 +339,7 @@ public:
    *        If #Allocator_raw is stateless, then this has size zero, so nothing is copied at runtime,
    *        and by definition it is to equal `Allocator_raw()`.
    */
-  Basic_blob(const Allocator_raw& alloc_raw = Allocator_raw());
+  Basic_blob(const Allocator_raw& alloc_raw = Allocator_raw{});
 
   /**
    * Constructs blob with size() and capacity() equal to the given `size`, and `start() == 0`.  Performance note:
@@ -360,7 +360,8 @@ public:
    *        If #Allocator_raw is stateless, then this has size zero, so nothing is copied at runtime,
    *        and by definition it is to equal `Allocator_raw()`.
    */
-  explicit Basic_blob(size_type size, log::Logger* logger_ptr = 0, const Allocator_raw& alloc_raw = Allocator_raw());
+  explicit Basic_blob(size_type size, log::Logger* logger_ptr = nullptr,
+                      const Allocator_raw& alloc_raw = Allocator_raw{});
 
   /**
    * Move constructor, constructing a blob exactly internally equal to pre-call `moved_src`, while the latter is
@@ -372,7 +373,7 @@ public:
    * @param logger_ptr
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    */
-  Basic_blob(Basic_blob&& moved_src, log::Logger* logger_ptr = 0);
+  Basic_blob(Basic_blob&& moved_src, log::Logger* logger_ptr = nullptr);
 
   /**
    * Copy constructor, constructing a blob logically equal to `src`.  More formally, guarantees post-condition wherein
@@ -399,7 +400,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) or asynchronously when TRACE-logging
    *        in the event of buffer dealloc.  Null allowed.
    */
-  explicit Basic_blob(const Basic_blob& src, log::Logger* logger_ptr = 0);
+  explicit Basic_blob(const Basic_blob& src, log::Logger* logger_ptr = nullptr);
 
   /**
    * Destructor that drops `*this` ownership of the allocated internal buffer if any, as by make_zero();
@@ -429,7 +430,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    * @return `*this`.
    */
-  Basic_blob& assign(Basic_blob&& moved_src, log::Logger* logger_ptr = 0);
+  Basic_blob& assign(Basic_blob&& moved_src, log::Logger* logger_ptr = nullptr);
 
   /**
    * Move assignment operator (no logging): equivalent to `assign(std::move(moved_src), nullptr)`.
@@ -510,7 +511,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    * @return `*this`.
    */
-  Basic_blob& assign(const Basic_blob& src, log::Logger* logger_ptr = 0);
+  Basic_blob& assign(const Basic_blob& src, log::Logger* logger_ptr = nullptr);
 
   /**
    * Copy assignment operator (no logging): equivalent to `assign(src, nullptr)`.
@@ -530,7 +531,7 @@ public:
    * @param logger_ptr
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    */
-  void swap(Basic_blob& other, log::Logger* logger_ptr = 0);
+  void swap(Basic_blob& other, log::Logger* logger_ptr = nullptr);
 
   /**
    * Applicable to `!zero()` blobs, this returns an identical Basic_blob that shares (co-owns) `*this` allocated buffer
@@ -552,7 +553,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    * @return An identical Basic_blob to `*this` that shares the underlying allocated buffer.  See above.
    */
-  Basic_blob share(log::Logger* logger_ptr = 0) const;
+  Basic_blob share(log::Logger* logger_ptr = nullptr) const;
 
   /**
    * Applicable to `!zero()` blobs, this shifts `this->begin()` by `size` to the right without changing
@@ -585,7 +586,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    * @return The split-off-on-the-left Basic_blob that shares the underlying allocated buffer with `*this`.  See above.
    */
-  Basic_blob share_after_split_left(size_type size, log::Logger* logger_ptr = 0);
+  Basic_blob share_after_split_left(size_type size, log::Logger* logger_ptr = nullptr);
 
   /**
    * Identical to share_after_split_left(), except `this->end()` shifts by `size` to the left (instead of
@@ -605,7 +606,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    * @return The split-off-on-the-right Basic_blob that shares the underlying allocated buffer with `*this`.  See above.
    */
-  Basic_blob share_after_split_right(size_type size, log::Logger* logger_ptr = 0);
+  Basic_blob share_after_split_right(size_type size, log::Logger* logger_ptr = nullptr);
 
   /**
    * Identical to successively performing `share_after_split_left(size)` until `this->empty() == true`;
@@ -641,7 +642,7 @@ public:
    */
   template<typename Emit_blob_func>
   void share_after_split_equally(size_type size, bool headless_pool, Emit_blob_func&& emit_blob_func,
-                                 log::Logger* logger_ptr = 0);
+                                 log::Logger* logger_ptr = nullptr);
 
   /**
    * share_after_split_equally() wrapper that places `Basic_blob`s into the given container via
@@ -660,7 +661,7 @@ public:
    */
   template<typename Blob_container>
   void share_after_split_equally_emit_seq(size_type size, bool headless_pool, Blob_container* out_blobs,
-                                          log::Logger* logger_ptr = 0);
+                                          log::Logger* logger_ptr = nullptr);
 
   /**
    * share_after_split_equally() wrapper that places `Ptr<Basic_blob>`s into the given container via
@@ -681,7 +682,7 @@ public:
    */
   template<typename Blob_ptr_container>
   void share_after_split_equally_emit_ptr_seq(size_type size, bool headless_pool, Blob_ptr_container* out_blobs,
-                                              log::Logger* logger_ptr = 0);
+                                              log::Logger* logger_ptr = nullptr);
 
   /**
    * Replaces logical contents with a copy of the given non-overlapping area anywhere in memory.  More formally:
@@ -700,7 +701,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    * @return Number of elements copied, namely `src.size()`, or simply size().
    */
-  size_type assign_copy(const boost::asio::const_buffer& src, log::Logger* logger_ptr = 0);
+  size_type assign_copy(const boost::asio::const_buffer& src, log::Logger* logger_ptr = nullptr);
 
   /**
    * Copies `src` buffer directly onto equally sized area within `*this` at location `dest`; `*this` must have
@@ -724,7 +725,7 @@ public:
    * @return Location in this blob just past the last element copied; `dest` if none copied; in particular end() is a
    *         possible value.
    */
-  Iterator emplace_copy(Const_iterator dest, const boost::asio::const_buffer& src, log::Logger* logger_ptr = 0);
+  Iterator emplace_copy(Const_iterator dest, const boost::asio::const_buffer& src, log::Logger* logger_ptr = nullptr);
 
   /**
    * The opposite of emplace_copy() in every way, copying a sub-blob onto a target memory area.  Note that the size
@@ -743,7 +744,7 @@ public:
    * @return Location in this blob just past the last element copied; `src` if none copied; end() is a possible value.
    */
   Const_iterator sub_copy(Const_iterator src, const boost::asio::mutable_buffer& dest,
-                          log::Logger* logger_ptr = 0) const;
+                          log::Logger* logger_ptr = nullptr) const;
 
   /**
    * Returns number of elements stored, namely `end() - begin()`.  If zero(), this is 0; but if this is 0, then
@@ -815,7 +816,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) or asynchronously when TRACE-logging
    *        in the event of buffer dealloc.  Null allowed.
    */
-  void reserve(size_type capacity, log::Logger* logger_ptr = 0);
+  void reserve(size_type capacity, log::Logger* logger_ptr = nullptr);
 
   /**
    * Guarantees post-condition `zero() == true` by dropping `*this` ownership of the allocated internal buffer if any;
@@ -840,7 +841,7 @@ public:
    * @param logger_ptr
    *        The Logger implementation to use in *this* routine (synchronously) only.  Null allowed.
    */
-  void make_zero(log::Logger* logger_ptr = 0);
+  void make_zero(log::Logger* logger_ptr = nullptr);
 
   /**
    * Guarantees post-condition `size() == size` and `start() == start`; no values in pre-call range `[begin(), end())`
@@ -868,7 +869,7 @@ public:
    *        The Logger implementation to use in *this* routine (synchronously) or asynchronously when TRACE-logging
    *        in the event of buffer dealloc.  Null allowed.
    */
-  void resize(size_type size, size_type start_or_unchanged = S_UNCHANGED, log::Logger* logger_ptr = 0);
+  void resize(size_type size, size_type start_or_unchanged = S_UNCHANGED, log::Logger* logger_ptr = nullptr);
 
   /**
    * Restructures blob to consist of an internally allocated buffer and a `[begin(), end)` range starting at
@@ -1293,7 +1294,7 @@ private:
    *   - Specifically it supports a perf-enhancing use mode: using `make_shared()` (and similar) instead of
    *     `.reset(<raw ptr>)` (or similar ctor) replaces 2 allocs (1 for user data, 1 for aux data/ref-count)
    *     with 1 (for both).
-   *   - If verbose logging in the deleter is desired its `virtual`-based type-erased deleter semantics make that
+   *   - If verbose logging in the deleter is desired, its `virtual`-based type-erased deleter semantics make that
    *     quite easy to achieve.
    *
    * ### The case where #S_SHARING is `false` ###
@@ -1335,7 +1336,7 @@ private:
    * @param logger_ptr
    *        See swap().
    */
-  void swap_impl(Basic_blob& other, log::Logger* logger_ptr = 0);
+  void swap_impl(Basic_blob& other, log::Logger* logger_ptr);
 
   /**
    * Returns iterator-to-mutable equivalent to given iterator-to-immutable.
@@ -1645,7 +1646,7 @@ void Basic_blob<Allocator, S_SHARING_ALLOWED>::swap(Basic_blob& other, log::Logg
   // For m_alloc_raw: Follow rules established in m_alloc_raw doc header.
   if constexpr(std::allocator_traits<Allocator_raw>::propagate_on_container_swap::value)
   {
-    if (&this->m_alloc_raw != &other.m_alloc_raw) // @todo Is this redundant?  Or otherwise unnecessary?
+    if (&m_alloc_raw != &other.m_alloc_raw) // @todo Is this redundant?  Or otherwise unnecessary?
     {
       swap(m_alloc_raw, other.m_alloc_raw);
     }
@@ -1678,7 +1679,7 @@ Basic_blob<Allocator, S_SHARING_ALLOWED> Basic_blob<Allocator, S_SHARING_ALLOWED
 
   assert(!zero()); // As advertised.
 
-  Basic_blob sharing_blob(m_alloc_raw, logger_ptr); // Null Basic_blob (let that ctor log via same Logger if any).
+  Basic_blob sharing_blob{m_alloc_raw, logger_ptr}; // Null Basic_blob (let that ctor log via same Logger if any).
   assert(!sharing_blob.m_buf_ptr);
   sharing_blob.m_buf_ptr = m_buf_ptr;
   // These are currently (as of this writing) uninitialized (possibly garbage).
@@ -1817,7 +1818,7 @@ void Basic_blob<Allocator, S_SHARING_ALLOWED>::share_after_split_equally_emit_pt
 
   share_after_split_equally(size, headless_pool, [&](Basic_blob&& blob_moved)
   {
-    out_blobs_ptr->push_back(Ptr(new Basic_blob(std::move(blob_moved))));
+    out_blobs_ptr->push_back(Ptr(new Basic_blob{std::move(blob_moved)}));
   }, logger_ptr);
 }
 
@@ -1964,7 +1965,7 @@ void Basic_blob<Allocator, S_SHARING_ALLOWED>::reserve(size_type new_capacity, l
                            * Since only we happen to know the size of how much we actually allocated, we pass that info
                            * into the Deleter_raw as well, as it needs to know the `n` to pass to
                            * m_alloc_raw.deallocate(p, n). */
-                          Deleter_raw(m_alloc_raw, new_capacity));
+                          Deleter_raw{m_alloc_raw, new_capacity});
           /* Note: Unlike the S_IS_VANILLA_ALLOC=true case above, here we omit any attempt to log at the time
            * of dealloc, even if the verbosity is currently set high enough.  It is not practical to achieve:
            * Recall that the assumptions we take for granted when dealing with std::allocator/regular heap
@@ -1999,7 +2000,7 @@ void Basic_blob<Allocator, S_SHARING_ALLOWED>::reserve(size_type new_capacity, l
            * or we can assign via unique_ptr move-ct.  The latter is certainly pithier and prettier,
            * but the former might be a bit faster.  (Caution!  Recall m_buf_ptr is null currently.  If it were not
            * we would need to explicitly nullify it before the get_deleter() assignment.) */
-          m_buf_ptr.get_deleter() = Deleter_raw(m_alloc_raw, new_capacity);
+          m_buf_ptr.get_deleter() = Deleter_raw{m_alloc_raw, new_capacity};
           m_buf_ptr.reset(m_alloc_raw.allocate(new_capacity));
         } // else if constexpr(!S_SHARING)
       } // else if constexpr(!S_IS_VANILLA_ALLOC)
@@ -2191,7 +2192,7 @@ typename Basic_blob<Allocator, S_SHARING_ALLOWED>::Iterator
      * This occurs due to (among other things) inlining from above our frame down into the std::memcpy() call
      * we make; plus allegedly the C++ front-end supplying the huge values during the diagnostics pass.
      * No such huge values (which are 0x800000000000000F, 0xFFFFFFFFFFFFFFFF, 0x7FFFFFFFFFFFFFFF, respectively)
-     * is actually passed-in at run-time nor mentioned anywhere
+     * are actually passed-in at run-time nor mentioned anywhere
      * in our code, here or in the unit-test(s) triggering the auto-inlining triggering the warning.  So:
      *
      * The warning is wholly inaccurate in a way reminiscent of the situation in reserve() with a somewhat
@@ -2204,7 +2205,7 @@ typename Basic_blob<Allocator, S_SHARING_ALLOWED>::Iterator
 #pragma GCC diagnostic ignored "-Wrestrict" // Another similar bogus one pops up after pragma-ing away preceding one.
 
     /* Likely linear-time in `n` but hopefully optimized.  Could use a C++ construct, but I've seen that be slower
-     * that a direct memcpy() call in practice, at least in a Linux gcc.  Could use boost.asio buffer_copy(), which
+     * than a direct memcpy() call in practice, at least in a Linux gcc.  Could use boost.asio buffer_copy(), which
      * as of this writing does do memcpy(), but the following is an absolute guarantee of best performance, so better
      * safe than sorry (hence this whole Basic_blob class's existence, at least in part). */
     memcpy(dest_it, src_data, n);
@@ -2450,15 +2451,13 @@ typename Basic_blob<Allocator, S_SHARING_ALLOWED>::Iterator
 template<typename Allocator, bool S_SHARING_ALLOWED>
 boost::asio::const_buffer Basic_blob<Allocator, S_SHARING_ALLOWED>::const_buffer() const
 {
-  using boost::asio::const_buffer;
-  return const_buffer(const_data(), size());
+  return boost::asio::const_buffer{const_data(), size()};
 }
 
 template<typename Allocator, bool S_SHARING_ALLOWED>
 boost::asio::mutable_buffer Basic_blob<Allocator, S_SHARING_ALLOWED>::mutable_buffer()
 {
-  using boost::asio::mutable_buffer;
-  return mutable_buffer(data(), size());
+  return boost::asio::mutable_buffer{data(), size()};
 }
 
 template<typename Allocator, bool S_SHARING_ALLOWED>

--- a/src/flow/util/shared_ptr_alias_holder.hpp
+++ b/src/flow/util/shared_ptr_alias_holder.hpp
@@ -105,6 +105,13 @@ namespace flow::util
  * @todo flow::util::Shared_ptr_alias_holder `Const_target_ptr` is deprecated and shall be always left at its default
  *       value in future code; eventually remove it entirely and hard-code the default value internally.
  *
+ * @todo flow::util::Shared_ptr_alias_holder, such as it is, may well largely work for `unique_ptr` and other
+ * smart/fancy pointer types; should be generalized both in name (if possible) and capabilities (if not already
+ * the case).  Could be just a matter of updating docs and renaming (deprecated-path alias may be required to
+ * avoid a breaking change); or not.  Needs a bit of investigation to determine such details.  (The author (ygoldfel)
+ * was conisderably less advanced when this was originally made versus the time of this writing... maybe a
+ * decade+?  He meant well though.)
+ *
  * @todo Add example usage snippets in Shared_ptr_alias_holder doc header, illustrating the pattern.
  */
 template<typename Target_ptr,


### PR DESCRIPTION
Comment and/or doc change. / Minor internal style tweaks. / `flow::log::Logger::this_thread_set_logged_nickname()`, used also by various oft-used facilities including much of flow.async, now truncates the Linux-specific thread name from the back instead of from the front.  (It was thought the latter technique would help disambiguate things better, when the 15-char limit was exceeded, but the opposite has become apparent over time.) / `flow::log::Async_file_logger` background log-writing thread was nicknamed something beyond Linux thread name length limit which had to be truncated; now will be, e.g., "ASFL-0x34567890" which could fit. / `flow::async::optimize_pinning_in_thread_pool()` free function API has been updated to take an optional `Error_code*`, thus becoming compliant with the standard Flow error-emission pattern (not a breaking change; behavior without supplying this arg does not change and is compliant with the pattern already). / Minor internal house-keeping in `flow::async::optimize_pinning_in_thread_pool()` and nearby. / Added `flow::async::reset_thread_pinning()` and `reset_this_thread_pinning()` free function APIs which reset the core-affinity of the given -- or calling -- thread to the default state of having no preference for any particular core(s), leaving the migration decisions to the OS.  This may be helpful for, e.g., background workers spawned by libraries (such as flow.log) that would otherwise inherit whatever core-affinity that may be configured for the thread of the lib user. / Using `flow::async::reset_this_thread_pinning()` at the start of the `flow::log::Async_file_logger` worker thread which should remain as independent and responsive as possible.

related to #108, #71, Flow-IPC/ipc#85

* New APIs:
  * Added `flow::async::reset_thread_pinning()` and `reset_this_thread_pinning()` free function APIs.
  * `flow::async::optimize_pinning_in_thread_pool()` free function API has been updated to take an optional `Error_code*`, thus becoming compliant with the standard Flow error-emission pattern (not a breaking change).

## To code reviewer
Forgoing code review, because already reviewed elsewhere (@code-walkers).